### PR TITLE
Support ?load= and ?id= search params

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ on essential complexity and walls between language/env authors | developer | end
 
 # HOW TO TRY
 
-1. https://model-view-self-modify.netlify.app/ (or open `index.html` locally, or serve it by e.g. `python3 -m http.server`).  
-2. Paste the content of [tetris.js](tetris.js) into the editor.
-3. Start moving "TIME TRAVEL" line up.
-4. Put editor cursor before it and start clicking [left] [right] [down] buttons to play from that moment.
-5. Put cursor inside `RCSet([...])` in `newGame.board`.  Start clicking board cells to mark them occupied.
+1. https://model-view-self-modify.netlify.app/?load=tetris.js (or serve locally by e.g. `python3 -m http.server`).  
+2. Start moving "TIME TRAVEL" line up.
+3. Put editor cursor before it and start clicking [left] [right] [down] buttons to play from that moment.
+4. Put cursor inside `RCSet([...])` in `newGame.board`.  Start clicking board cells to mark them occupied.
 
-# Implementation things I learnet in 1st week of prototyping
+# Implementation things I learnt in 1st week of prototyping
 
 * localStorage is awesome for edit/reload development!
   2 lines for major quality of life improvement

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
   // --- https://stackoverflow.com/a/76452154/239657 ---
 
-  const GeneratorFunction = function* () { }.constructor;
+  const GeneratorFunction = function* () { }.constructor
 
   // sourceURL pragma makes stack traces more readable.
   var sourcePragma = '\n//# sourceURL=evaluated-code'
@@ -338,14 +338,14 @@
 
       return () => {
         view.destroy()
-      };
+      }
     }, [])
 
     return html`<div className=${className} ref=${editor} />`
   }
 
   var Inspect = ({ obj }) => {
-    const ref = useRef(null);
+    const ref = useRef(null)
     useEffect(() => {
       // TODO: we're leaking Inspector instances on each render, is that OK?
       const inspector = new Inspector(ref.current)
@@ -436,29 +436,28 @@
     // TODO: linkify line:column
     html`<div style=${{ whiteSpace: 'pre-wrap', textAlign: 'left', fontFamily: 'monospace', color: '#a00' }}>
       ${children}
-    </div>`;
+    </div>`
 
   class ErrorBoundary extends Component {
-    state = {};
+    state = {}
 
     componentDidCatch(error, info) {
-      this.setState({ error: error.toString(), componentStack: info?.componentStack });
+      this.setState({ error: error.toString(), componentStack: info?.componentStack })
       console.warn(this.state)
     }
 
     render() {
-      const { error, componentStack } = this.state;
+      const { error, componentStack } = this.state
       if (error) {
         return html`<${ShowError}>
             ${error}
             ${componentStack}
-          <//>`;
+          <//>`
       }
 
-      return this.props.children;
+      return this.props.children
     }
   }
-
 
   render(html`<${EditEvalRenderLoop} />`, document.body)
 </script>

--- a/index.html
+++ b/index.html
@@ -183,11 +183,11 @@
   var demoCode = 'return (props) => html`<a href="/">Hello!</a>`'
 
   var EditEvalRenderLoop = (props) => {
-    const [code, setCode] = useState(localStorage.getItem('code') || demoCode)
+    const [code, setCode] = useState(props.initialCode)
 
     const saveCode = (code) => {
-      console.log('saveCode')
-      localStorage.setItem('code', code)
+      console.log('saveCode to id:', props.localStorageId)
+      localStorage.setItem(props.localStorageId, code)
       setCode(code)
     }
 
@@ -459,5 +459,27 @@
     }
   }
 
-  render(html`<${EditEvalRenderLoop} />`, document.body)
+  const loadUrl = new URLSearchParams(location.search).get('load')
+  var localStorageId = new URLSearchParams(location.search).get('id') || loadUrl || 'code'
+  console.log('localStorage from id:', localStorageId, 'got:', localStorage.getItem(localStorageId))
+  // Deliberately not distinguishing null from previously stored empty string.
+  // So deleting all code + reload is a way to get demoCode back.
+  var code = localStorage.getItem(localStorageId) || demoCode
+  if (loadUrl) {
+    console.log('fetching:', loadUrl)
+    fetch(loadUrl).then(response => {
+      response.text().then(text => {
+        if (!response.ok) {
+          throw new Error(`fetching \`${loadUrl}\`: HTTP ${response.status} ${response.statusText}`);
+        }
+        // TODO can overwrite user's work unconditionally!
+        render(html`<${EditEvalRenderLoop} initialCode=${text} localStorageId=${localStorageId} />`, document.body)
+      }).catch(reason => {
+        code = '/*\n' + reason.toString() + '\n*/\n\n' + code
+        render(html`<${EditEvalRenderLoop} initialCode=${code} localStorageId=${localStorageId} />`, document.body)
+      })
+    })
+  } else {
+    render(html`<${EditEvalRenderLoop} initialCode=${code} localStorageId=${localStorageId} />`, document.body)
+  }
 </script>


### PR DESCRIPTION
Main use case is to allow `?load=tetris.js` (taking relative or absolute URL)
This in turn should allow separate embedding demos in iframes into longer prose.

- localStorage is by origin, not URL so would still collide.
  Previously always used single `code` key; now using `?load=...` URL as key (overridable by `?id=...`)
- [ ] Unsolved problem that `?load=...` will overwrite user's edits on every reload, **silently**.